### PR TITLE
Time-to-time service message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ MSGS_FILES = $(shell find . -name '*.msg') $(shell find . -name '*.srv')
 .PHONY: docs clean view venv pdf 
 
 docs: html
-	@echo "MD files: $(MD_FILES)"
-	@echo "msgs files: $(MSGS_FILES)"
 
 clean:
 	@echo "Removing files"

--- a/srv/motion_planning/PointToPointTime.srv
+++ b/srv/motion_planning/PointToPointTime.srv
@@ -1,0 +1,9 @@
+# Service that provides an estimate of the time to perform point-to-point motion to different poses.
+
+# Let "n" be the number of poses, this service builds a "n x n" time-transition matrix containing, where each entry "t[i, j]" contains the time (in seconds) required to move from pose "i" to pose "j".
+
+geometry_msgs/Pose[] poses
+string frame_id             # reference frame in which poses are defined;
+
+---
+std_msgs/Float64MultiArray time_transition_matrix

--- a/srv/task_planning/Orienteering.srv
+++ b/srv/task_planning/Orienteering.srv
@@ -1,16 +1,15 @@
-# DISCLAIMER: this will not be the final messagge to describe a defect.
-# This is a temporary placeholder for demonstration purposes.
+# Service that provides the optimal sequence of defects to be reworked as the solution of an orienteering problem
 
-uint8 NUM_ANT_COL = 1  # Ant colony algorithm.
-uint8 NUM_GUROBI = 2  # Gurobi
-uint8 NUM_GENETIC = 3  # Genetic algorithm.
-uint8 NUM_PROFIT_RATIO = 4 # Profit ratio search.
+uint8 ALGORITHM_ANT_COL = 1  # Ant colony algorithm.
+uint8 ALGORITHM_GUROBI = 2  # Gurobi
+uint8 ALGORITHM_GENETIC = 3  # Genetic algorithm.
+uint8 ALGORITHM_PROFIT_RATIO = 4 # Profit ratio search.
 
-magician_msgs/Defect[] defects
-float64[] travel_times
-float64 max_time
-float64 max_compute_time
-uint8 algorithm
+geometry_msgs/PoseStamped initial_pose  # starting end-effector configuration;
+magician_msgs/Defect[] defects          # list of scanned defect;
+float64 max_time                        # maximum time budget (in seconds) for the roadmap execution;
+float64 max_compute_time                # maximum time (in seconds) that the solver can use to find a solution;
+uint8 algorithm                         # algorithm to be used; see the constants exported by this message.
 ---
-magician_msgs/Defect[] roadmap
-float64[] service_times
+magician_msgs/Defect[] roadmap  # ordered sequence of defects to be reworked;
+float64[] service_times         # service time (in seconds) for each defect removal operation.


### PR DESCRIPTION
@SwonGao @GeertDriessenPipple @PatrickPipple 

Hi, I wrote my proposal for the message that shall build for you the time transition matrix required to reach any pair of defects.

First, I updated your [`Orienteering.srv`](https://github.com/magician-project/magician_msgs/blob/fc1addf90243ec6afcc21cafcd4e919b4a32f9cf/srv/task_planning/Orienteering.srv#L8) message to include the initial end-effector configuration of the robot as an "extra" variable; I also added some documentation to your message.

I then created my own [`PointToPointTime.srv`](https://github.com/magician-project/magician_msgs/blob/devel-dmp/srv/motion_planning/PointToPointTime.srv) custom service message.
You may read the documentation of the message there, but overall my proposal is to have the orienteering-solver node that creates the ordered list of poses over which my algorithm provides the solution. 
From my point of view, this choice enables you to decide _where_ you want the initial condition of the robot to be in the graph (you may put it first or last, but my service will not care), so on your side you simply need to create a list of poses. Note that

- the [defects](https://github.com/magician-project/magician_msgs/blob/main/msg/Defect.msg) already contains location data;
- you may, in the worst case, rely on TF2 to convert either the defect pose or the end-effector initial configuration into a common reference frame.


Let me know if there's something which is not that clear, I will do my best to explain that.



**Note:** @SwonGao I also changed the names of the constants in the [`Orienteering.srv`](https://github.com/magician-project/magician_msgs/blob/fc1addf90243ec6afcc21cafcd4e919b4a32f9cf/srv/task_planning/Orienteering.srv#L3-L6) message definition to make them have a more meaningful definition when reading. Let me know if you like such change or I revert back to the "original" definition. Note that if we accept this change, you may need to update your orienteering code (definitely you shall change [this code](https://github.com/magician-project/op_solver/blob/d9cb585186ff9f8ee88e26bb3eafef95b3e80783/op_solver_node/op_service_node.py#L50-L62), but I don't know if those constants are used somewhere else).