### PR TITLE
Fixed service definition for ergodic control

### DIFF
--- a/srv/motion_planning/ExecuteTrajectoryOnMesh.srv
+++ b/srv/motion_planning/ExecuteTrajectoryOnMesh.srv
@@ -3,7 +3,8 @@
 
 string mesh                     # mesh where the motion shall be planned on. See the :ref:`mesh-handling` guide in the documentation for more references
 string frame_link               # name of the link in which the trajectory is defined
-geometry_msgs/Pose[] path       # path to be executed
+geometry_msgs/Point[] path      # position path to be executed
+float64 path_freq_hz            # frequency of the provided path (in Hz)
 float64 offset                  # offset, in meters, of the trajectory from the mesh
 bool plan_y0_motion true        # wether a motion to reach y0 shall be executed or not
 float64 approach_vel 0.15      


### PR DESCRIPTION
Since we expect the ergodic control on mesh to provide a **position-only** path on the mesh, I adjusted the `ExecuteTrajectoryOnMesh` as follows:

- use of `geometry_msgs/Point[]` to represent the path instead of `geometry_msgs/Pose[]` (since the orientation information provided is effectively useless);
- added a new field (`path_freq_hz`) which specifies the frequency at which the path points shall be broadcasted. This information is required by the motion planner to properly upsample (if necessary) the trajectory.

Note that these are breaking changes for the callers of such a service.