### PR TITLE
Add probability_no_defect field to TactileDetection.msg

### DIFF
--- a/msg/TactileDetection.msg
+++ b/msg/TactileDetection.msg
@@ -5,3 +5,4 @@ std_msgs/Header header    # Start time of the analyzed window (seconds)
 float32 timewindow_size_ms      # End time of the analyzed window (seconds)
 string type                 # Type of defect detected (e.g., "no defect", "defect", "NDA", "PDA")
 float32 probability         # Confidence/probability of the defect (0.0 to 1.0)
+float32 probability_no_defect   # Probability of no defect: prob[class=0] regardless of prediction


### PR DESCRIPTION
The probability field only describes the probability of the type it predicted. To avoid confusion, we also need probability of no defect. This helps in the case of binary and multi classification